### PR TITLE
Fix library sort and librarylist display when filtered

### DIFF
--- a/backend/src/utils/helper.js
+++ b/backend/src/utils/helper.js
@@ -10,10 +10,10 @@ const fetchJson = async (url, options = {}) => {
 
 const categoryKeywords = {
   'Jeunesse & Young Adult': ['juvenile', 'young adult', 'children', "children's books", 'kids', 'teen', 'picture books', 'tween', 'middle grade', 'YA'],
-  'Littérature': ['fiction', 'paranormal', 'poetry', 'drama', 'literary', 'criticism', 'novel', 'short stories', 'narrative', 'classics'],
-  'Fantaisie & SF': ['fantasy', 'science fiction', 'fiction fantasy', 'fantasy fiction', 'fiction / fantasy'],
+  'Fantasy & SF': ['fantasy', 'science fiction', 'fiction fantasy', 'fantasy fiction', 'fiction / fantasy'],
   'Policier': ['detective', 'mystery', 'detective novel', 'detective stories', 'detective fiction', 'thrillers', 'suspense', 'crime & mystery'],
   'BD & Manga': ['comics', 'graphic novels', 'manga', 'bd', 'anime', 'superhero', 'comic book'],
+  'Littérature': ['fiction', 'paranormal', 'poetry', 'drama', 'literary', 'criticism', 'novel', 'short stories', 'narrative', 'classics'],
   'Business': ['business', 'economics', 'finance', 'law', 'political', 'management', 'money', 'investing', 'entrepreneurship', 'startup', 'leadership', 'marketing', 'strategy'],
   'Développement Personnel': ['body', 'mind', 'spirit', 'self-help', 'health', 'fitness', 'psychology', 'wellness', 'motivation', 'productivity', 'happiness', 'meditation', 'mental health'],
   'Non-fiction': [

--- a/frontend/src/pages/shelves/LibraryList.jsx
+++ b/frontend/src/pages/shelves/LibraryList.jsx
@@ -98,6 +98,12 @@ function LibraryList() {
   // Group books into an object like { "Science-Fiction": [book, ...], "Littérature": [book, ...] }
   const grouped = groupByGenre(filteredBooks());
 
+  // Compute available categories for the current filter
+  const filteredBooksArr = filteredBooks();
+  const availableCategories = Array.from(
+    new Set(filteredBooksArr.map((book) => book.category || 'Autres'))
+  ).sort((a, b) => a.localeCompare(b));
+
   // Filter have and have read
   const handleFilterClick = (filterValue) => {
     setActiveFilter(filterValue);
@@ -198,7 +204,7 @@ function LibraryList() {
                 </Listbox.Option>
 
                 {/* Category options */}
-                {categories.map((cat) => (
+                {availableCategories.map((cat) => (
                   <Listbox.Option
                     key={cat}
                     value={cat}
@@ -234,47 +240,62 @@ function LibraryList() {
         </Listbox>
       </div>
 
-      {/* Render "Shelves" */}
-      {Object.entries(grouped).map(([genre, books]) => {
-        // If user selected a specific category, skip rendering shelves of other genres.
-        if (selectedCategory && selectedCategory !== genre) {
-          return null;
-        }
+      {/* Render "Shelves" or grid depending on filter */}
+      {selectedCategory ? (
+        <div className='flex flex-wrap gap-8 mt-8 mb-6 xs:mb-8 sm:mb-10'>
+          {(grouped[selectedCategory] || [])
+            .slice()
+            .reverse()
+            .map((bookItem) => (
+              <BookInLibrary key={bookItem.isbn} book={bookItem} />
+            ))}
+        </div>
+      ) : (
+        Object.entries(grouped).map(([genre, books]) => {
+          return (
+            <div key={genre} className='mb-6 xs:mb-8 sm:mb-10'>
+              {/* Shelf heading */}
+              <h4 className='text-h6 xs:text-h5 min-[1450px]:text-h4 text-black-100 font-merriweather mb-2'>
+                {genre}
+              </h4>
 
-        return (
-          <div key={genre} className='mb-6 xs:mb-8 sm:mb-10'>
-            {/* Shelf heading */}
-            <h4 className='text-h6 xs:text-h5 min-[1450px]:text-h4 text-black-100 font-merriweather mb-2'>
-              {genre}
-            </h4>
-
-            <Swiper
-              slidesPerView={2}
-              spaceBetween={0}
-              navigation={true}
-              breakpoints={{
-                700: {
-                  slidesPerView: 3,
-                },
-                970: {
-                  slidesPerView: 5,
-                },
-                1350: {
-                  slidesPerView: 8,
-                },
-              }}
-              modules={[Pagination, Navigation]}
-              className='mySwiper'
-            >
-              {books.map((bookItem) => (
-                <SwiperSlide key={bookItem.isbn}>
-                  <BookInLibrary book={bookItem} />
-                </SwiperSlide>
-              ))}
-            </Swiper>
-          </div>
-        );
-      })}
+              <Swiper
+                slidesPerView={2}
+                spaceBetween={0}
+                navigation={true}
+                breakpoints={{
+                  525: {
+                    slidesPerView: 3,
+                  },
+                  700: {
+                    slidesPerView: 4,
+                  },
+                  900: {
+                    slidesPerView: 5,
+                  },
+                  1050: {
+                    slidesPerView: 6,
+                  },
+                  1450: {
+                    slidesPerView: 8,
+                  },
+                }}
+                modules={[Pagination, Navigation]}
+                className='mySwiper'
+              >
+                {books
+                  .slice()
+                  .reverse()
+                  .map((bookItem) => (
+                    <SwiperSlide key={bookItem.isbn}>
+                      <BookInLibrary book={bookItem} />
+                    </SwiperSlide>
+                  ))}
+              </Swiper>
+            </div>
+          );
+        })
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/shelves/Wishlist.jsx
+++ b/frontend/src/pages/shelves/Wishlist.jsx
@@ -32,7 +32,7 @@ function Wishlist() {
           Wishlist
         </h3>
       </div>
-      <div className='flex flex-wrap gap-4 mt-[16px] xs:mt-[32px]'>
+      <div className='flex flex-wrap gap-8 mt-[16px] xs:mt-[32px]'>
         {wishlistBooks.length > 0 &&
           wishlistBooks.map((book, index) => {
             return (

--- a/frontend/src/utils/categories.js
+++ b/frontend/src/utils/categories.js
@@ -1,7 +1,7 @@
 export const categoryOptions = [
   'Jeunesse & Young Adult',
   'Littérature',
-  'Fantaisie & SF',
+  'Fantasy & SF',
   'Policier',
   'BD & Manga',
   'Business',


### PR DESCRIPTION
Resolves #8 :
- Sort the book list from most recently added
- Switch to flex (flex-wrap) view when category filter is active
- Adjusted flex gap in Wishlist to match with the one in LibraryList (gap-8)
- Fixed typo for category name : "Fantaisie" changed to "Fantasy" to match french library standard
- Moved "Fantasy & SF" category back up the categoryKeywords object to prioritise category assignment when looping through